### PR TITLE
migration file drop_table_searche deleted

### DIFF
--- a/db/migrate/20210407093712_drop_searches.rb
+++ b/db/migrate/20210407093712_drop_searches.rb
@@ -1,5 +1,0 @@
-class DropSearches < ActiveRecord::Migration[6.0]
-  def change
-    drop_table :searches
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_04_07_093712) do
+ActiveRecord::Schema.define(version: 2021_04_03_095127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
J'ai delete le dernier fichier de migration car aucune table search n'avait été créé 
